### PR TITLE
fix: expose branch when --release-pr flag is active

### DIFF
--- a/src/semantishPrerelease.js
+++ b/src/semantishPrerelease.js
@@ -21,11 +21,19 @@ module.exports = async function semantishPrerelease(
   return proxyquire('semantic-release', {
     './lib/get-next-version': getNextVersion,
     './lib/git': git,
-    'env-ci': (subContext) => ({
-      ...getEnvCi(subContext),
-      ...(options.releasePr
-        ? { isPr: false, pr: undefined, prBranch: undefined }
-        : {}),
-    }),
+    'env-ci': (subContext) => {
+      const envCi = getEnvCi(subContext);
+      if (!options.releasePr || !envCi.pr) {
+        return envCi;
+      }
+
+      return {
+        ...envCi,
+        isPr: false,
+        pr: undefined,
+        prBranch: undefined,
+        branch: envCi.branch || envCi.prBranch,
+      };
+    },
   })(await getOptions(options, context), context);
 };


### PR DESCRIPTION
fixes an issue where semantic release could not get branch info
since prBranch of env-ci was set to undefined

<!-- decorate-gh-pr -->
<hr /><code>npm install semantish-prerelease@3.1.1-test.ec2b907</code>
<!-- /decorate-gh-pr -->